### PR TITLE
Possibility to specify a Custom Base App in pipeline

### DIFF
--- a/.azureDevOps/CI.yml
+++ b/.azureDevOps/CI.yml
@@ -19,6 +19,11 @@ parameters:
   displayName: 'Specifies the path to the build-settings.json file'
   type: string
   default: '.azureDevOps\build-settings.json'
+- name: customBaseAppUrl
+  displayName: 'Specifies the url to the a Customer Base App to use in build container'
+  type: string
+  default: ''
+
 
 stages:
 - stage: Build
@@ -75,6 +80,15 @@ stages:
         targetType: filePath
         filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Create-Container.ps1'
         arguments: '-configurationFilePath "$(Build.Repository.LocalPath)\${{ parameters.configurationFilePath }}"'
+        failOnStderr: true
+
+    - task: PowerShell@2
+      displayName: 'Publish Custom Base App'
+      condition: and(succeeded(),ne(${{ parameters.configurationFilePath }},''))
+      inputs:
+        targetType: filePath
+        filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Publish-CustomBaseApp'
+        arguments: '-customBaseAppUrl ${{ parameters.configurationFilePath }}'
         failOnStderr: true
 
     - task: PowerShell@2

--- a/.azureDevOps/CI.yml
+++ b/.azureDevOps/CI.yml
@@ -87,7 +87,7 @@ stages:
       condition: and(succeeded(),ne('${{ parameters.customBaseAppUrl}}',''))
       inputs:
         targetType: filePath
-        filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Publish-CustomBaseApp'
+        filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Publish-CustomBaseApp.ps1'
         arguments: '-customBaseAppUrl ${{ parameters.customBaseAppUrl }}'
         failOnStderr: true
 

--- a/.azureDevOps/CI.yml
+++ b/.azureDevOps/CI.yml
@@ -84,11 +84,11 @@ stages:
 
     - task: PowerShell@2
       displayName: 'Publish Custom Base App'
-      condition: and(succeeded(),ne(${{ parameters.configurationFilePath }},''))
+      condition: and(succeeded(),ne('${{ parameters.customBaseAppUrl}}',''))
       inputs:
         targetType: filePath
         filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Publish-CustomBaseApp'
-        arguments: '-customBaseAppUrl ${{ parameters.configurationFilePath }}'
+        arguments: '-customBaseAppUrl ${{ parameters.customBaseAppUrl }}'
         failOnStderr: true
 
     - task: PowerShell@2

--- a/scripts/Publish-CustomBaseApp.ps1
+++ b/scripts/Publish-CustomBaseApp.ps1
@@ -1,0 +1,10 @@
+Param(
+    [Parameter(Mandatory = $false)]
+    [string] $customBaseAppUrl = '',
+
+    [Parameter(Mandatory = $false)]
+    [string] $containerName = $ENV:CONTAINERNAME
+)
+
+Write-Host "Publishing $customBaseAppUrl"
+Publish-NavContainerApp -containerName $containerName -appFile $customBaseAppUrl -skipVerification -sync -upgrade


### PR DESCRIPTION
If a custom base app is used when developing the pipeline needs to support specifying one in the setup. If you specify an URL in the parameter customBaseAppUrl the pipeline will download and publish this app after creating the build container and before trying to compile the app. The step is skipped if no Url is specified in the parameter.