### PR TITLE
Container name and image name change

### DIFF
--- a/scripts/Read-Settings.ps1
+++ b/scripts/Read-Settings.ps1
@@ -111,21 +111,28 @@ else {
     if ($imageName -eq "") {
         $containerNamePrefix = "bld"
     }
-    else {
-        $containerNamePrefix = "$imageName"
-    }
+    
     Write-Host "Set imageName = $imageName"
     Write-Host "##vso[task.setvariable variable=imageName]$imageName"
 }
 
 Write-Host "Repository: $($ENV:BUILD_REPOSITORY_NAME)"
 Write-Host "Build Reason: $($ENV:BUILD_REASON)"
-$buildName = ($ENV:BUILD_BUILDNUMBER -replace '[^a-zA-Z0-9]', '').Substring(8)
-$buildName += ($ENV:BUILD_REPOSITORY_NAME).Split('/')[1]
+
+$buildName = ($ENV:BUILD_REPOSITORY_NAME).Split('/')[1]
+
+if ([string]::IsNullOrEmpty($buildName)) {
+    $buildName = ($ENV:BUILD_REPOSITORY_NAME).Split('/')[0]
+}
+
+$buildName = $buildName + ($ENV:BUILD_BUILDNUMBER -replace '[^a-zA-Z0-9]', '').Substring(8)
+
 $containerName = "$($containerNamePrefix)$("${buildName}" -replace '[^a-zA-Z0-9]', '')".ToUpper()
+
 if ($containerName.Length -gt 15) {
     $containerName = $containerName.Substring(0, 15)
 }
+
 Write-Host "Set containerName = $containerName"
 Write-Host "##vso[task.setvariable variable=containerName]$containerName"
 


### PR DESCRIPTION
Changed how Container Name and Image name are set. Use Branch Name as container name. And use Image name setting for the docker images. I want to use the same image name for all our builds. This to minimize the creation of images.

Co-authored-by: Mathias Stjernfelt <mathias@brightcom.se>