### PR TITLE
Access private azure storage containers (#8)

### DIFF
--- a/.azureDevOps/CI.yml
+++ b/.azureDevOps/CI.yml
@@ -95,7 +95,10 @@ stages:
       displayName: 'Reading Settings'
       env:
         Password: $(Password)
-        SyncAppMode: ${{ parameters.SyncAppMode }}"       
+        SyncAppMode: ${{ parameters.SyncAppMode }}"
+        azstoragetenantid: $(AzStorageTenantId)
+        azstorageclientid: $(AzStorageClientId)
+        azstorageclientSecret: $(AzStorageClientSecret)          
       inputs:
         targetType: filePath
         filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Read-Settings.ps1'
@@ -104,6 +107,10 @@ stages:
     
     - task: PowerShell@2
       displayName: 'Install bccontainerhelper'
+      env:
+        azstoragetenantid: $(AzStorageTenantId)
+        azstorageclientid: $(AzStorageClientId)
+        azstorageclientSecret: $(AzStorageClientSecret)          
       inputs:
         targetType: filePath
         filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Install-bccontainerhelper.ps1'
@@ -116,6 +123,9 @@ stages:
         Password: $(Password)
         LicenseFile: $(LicenseFile)
         InsiderSasToken: $(InsiderSasToken)
+        azstoragetenantid: $(AzStorageTenantId)
+        azstorageclientid: $(AzStorageClientId)
+        azstorageclientSecret: $(AzStorageClientSecret)          
       inputs:
         targetType: filePath
         filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Create-Container.ps1'
@@ -150,6 +160,9 @@ stages:
       env:
         codeSignPfxFile: $(CodeSignPfxFile)
         codeSignPfxPassword: $(CodeSignPfxPassword)
+        azstoragetenantid: $(AzStorageTenantId)
+        azstorageclientid: $(AzStorageClientId)
+        azstorageclientSecret: $(AzStorageClientSecret)          
       inputs:
         targetType: filePath
         filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Sign-App.ps1'
@@ -221,6 +234,9 @@ stages:
       env:
         codeSignPfxFile: $(CodeSignPfxFile)
         codeSignPfxPassword: $(CodeSignPfxPassword)
+        azstoragetenantid: $(AzStorageTenantId)
+        azstorageclientid: $(AzStorageClientId)
+        azstorageclientSecret: $(AzStorageClientSecret)          
       inputs:
         targetType: filePath
         filePath: '$(Agent.ToolsDirectory)\bcbuildtemplate\Sign-App.ps1'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.local
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
         - ClientSecret (optional for online tenant deployment)
         - PowerShellUsername (optional for powershell deployment)
         - PowerShellPassword (optional for powershell deployment)
+        - Access a private storage account for license, certificates and app dependencies
+          - AzStorageTenantId, Azure tenantid where the storage container is located
+          - AzStorageClientId, App Registration Client Id
+          - AzStorageClientSecret, App Registration Client Secret
     - InsiderBuilds
         - InsiderSasToken
 3.	Create DevOps pipeline

--- a/scripts/Create-Container.ps1
+++ b/scripts/Create-Container.ps1
@@ -27,6 +27,8 @@
     [bool] $reuseContainer = ($ENV:REUSECONTAINER -eq "True")
 )
 
+. (Join-Path $PSScriptRoot "HelperFunctions.ps1")
+
 if (-not ($artifact)) {
     if ($ENV:ARTIFACTURL) {
         Write-Host "Using Artifact Url variable"
@@ -102,6 +104,11 @@ if ($licenseFile) {
     $parameters += @{
         "licenseFile" = $ENV:LICENSEFILE
     }
+}
+
+# If azure storage App Registration information is provided and Url contains blob.core.windows.net, download licensefile using Oauth2 authentication
+if ($parameters.licenseFile -ne "" -and $ENV:DOWNLOADFROMPRIVATEAZURESTORAGE -and $parameters.licenseFile.Contains("blob.core.windows.net")) {
+    $parameters.licenseFile = Get-BlobFromPrivateAzureStorageOauth2 -blobUri $parameters.licenseFile
 }
 
 if ($buildenv -eq "Local") {

--- a/scripts/HelperFunctions.ps1
+++ b/scripts/HelperFunctions.ps1
@@ -1,0 +1,32 @@
+Function Get-BlobFromPrivateAzureStorageOauth2 {
+    param(
+        [Parameter(ValueFromPipelineByPropertyName, Mandatory = $true)]
+        [String]$blobUri
+    )
+
+    Write-Host "Getting new Auth Context"
+
+    $context = New-BcAuthContext -tenantID $ENV:AZSTORAGETENANTID -clientID $ENV:AZSTORAGECLIENTID -clientSecret $ENV:AZSTORAGECLIENTSECRET -scopes "https://storage.azure.com/.default"
+    
+    if (!$context) {
+        throw "Error retrieving Access token"
+    } else {
+        Write-Host "Access token retieved"
+    }
+
+    $date = Get-Date
+    $formattedDateTime = $date.ToUniversalTime().ToString("R")
+
+    $headers = @{ 
+        "Authorization" = "Bearer $($context.accessToken)"
+        "x-ms-version"  = "2017-11-09"
+        "x-ms-date" = "$formattedDateTime"        
+        "Content-Type" = "application/json"
+    }
+
+    $TempFile = New-TemporaryFile
+
+    Download-File -sourceUrl $blobUri -destinationFile $TempFile -headers $headers
+
+    return($TempFile)
+}

--- a/scripts/Install-BCContainerHelper.ps1
+++ b/scripts/Install-BCContainerHelper.ps1
@@ -5,20 +5,19 @@
 
 Write-Host "Version: $bccontainerhelperVersion"
 
-
 $module = Get-InstalledModule -Name bccontainerhelper -ErrorAction SilentlyContinue
 if ($module) {
     $versionStr = $module.Version.ToString()
     Write-Host "bccontainerhelper $VersionStr is installed"
     if ($bccontainerhelperVersion -eq "latest") {
         Write-Host "Determine latest bccontainerhelper version"
-        $latestVersion = (Find-Module -Name bccontainerhelper).Version
+        $latestVersion = (Find-Module -Name bccontainerhelper -AllowPrerelease).Version
         $bccontainerhelperVersion = $latestVersion.ToString()
         Write-Host "bccontainerhelper $bccontainerhelperVersion is the latest version"
     }
     if ($bccontainerhelperVersion -ne $module.Version) {
         Write-Host "Updating bccontainerhelper to $bccontainerhelperVersion"
-        Update-Module -Name bccontainerhelper -Force -RequiredVersion $bccontainerhelperVersion
+        Update-Module -Name bccontainerhelper -Force -RequiredVersion $bccontainerhelperVersion -AllowPrerelease
         Write-Host "bccontainerhelper updated"
     }
 }
@@ -29,7 +28,7 @@ else {
     }
     if ($bccontainerhelperVersion -eq "latest") {
         Write-Host "Installing bccontainerhelper"
-        Install-Module -Name bccontainerhelper -Force
+        Install-Module -Name bccontainerhelper -AllowPrerelease -Force
     }
     else {
         Write-Host "Installing bccontainerhelper version $bccontainerhelperVersion"

--- a/scripts/Publish-Dependencies.ps1
+++ b/scripts/Publish-Dependencies.ps1
@@ -15,6 +15,8 @@ Param(
     [switch] $skipVerification
 )
 
+. (Join-Path $PSScriptRoot "HelperFunctions.ps1")
+
 $settings = (Get-Content -Path $configurationFilePath -Encoding UTF8 | Out-String | ConvertFrom-Json)
 $settings.dependencies | ForEach-Object {
     Write-Host "Publishing $_"
@@ -23,17 +25,32 @@ $settings.dependencies | ForEach-Object {
     if ($_.EndsWith(".zip", "OrdinalIgnoreCase") -or $_.Contains(".zip?")) {        
         $appFolder = Join-Path $env:TEMP $guid.Guid
         $appFile = Join-Path $env:TEMP "$($guid.Guid).zip"
-        Write-Host "Downloading app file $($_) to $($appFile)"        
-        Download-File -sourceUrl $_ -destinationFile $appFile
+        Write-Host "Downloading app file $($_) to $($appFile)"  
+        
+        # If azure storage App Registration information is provided and Url contains blob.core.windows.net, download dependency zip using Oauth2 authentication        
+        if ($ENV:DOWNLOADFROMPRIVATEAZURESTORAGE -and $_.Contains("blob.core.windows.net")) {
+            $appFile = Get-BlobFromPrivateAzureStorageOauth2 -blobUri $_
+        }
+        else {
+            Download-File -sourceUrl $_ -destinationFile $appFile
+        }
+               
         New-Item -ItemType Directory -Path $appFolder -Force | Out-Null
         Write-Host "Extracting .zip file "
         Expand-Archive -Path $appFile -DestinationPath $appFolder
         Remove-Item -Path $appFile -Force
         $appFile = Get-ChildItem -Path $appFolder -Recurse -Include *.app -File | Select-Object -First 1
-    }  else {
+    } else {
         Write-Host "Downloading app file $($_) to $($appFile)"        
         $appFile = Join-Path $env:TEMP "$($guid.Guid).app"   
-        Download-File -sourceUrl $_ -destinationFile $appFile
+        
+        # If azure storage App Registration information is provided and Url contains blob.core.windows.net, download dependency app using Oauth2 authentication
+        if ($ENV:DOWNLOADFROMPRIVATEAZURESTORAGE -and $_.Contains("blob.core.windows.net")) {
+            $appFile = Get-BlobFromPrivateAzureStorageOauth2 -blobUri $_
+        }
+        else {
+            Download-File -sourceUrl $_ -destinationFile $appFile
+        }
     }
 
     Write-Host "Container deployment to ${containerName}"

--- a/scripts/Read-Settings.ps1
+++ b/scripts/Read-Settings.ps1
@@ -179,3 +179,12 @@ Write-Host "##vso[task.setvariable variable=testCodeunitId]$testCodeunitId"
 $testMethodName = $settings.TestMethod.MethodName
 Write-Host "Set testMethodName = $testMethodName"
 Write-Host "##vso[task.setvariable variable=testMethodName]$testMethodName"
+
+if ($ENV:AZSTORAGETENANTID -ne "`$(AzStorageTenantId)" -and $ENV:AZSTORAGETENANTID -ne "") { $AzStorageTenantIdIsSet = $true } else { $AzStorageTenantIdIsSet = $false }
+if ($ENV:AZSTORAGECLIENTID -ne "`$(AzStorageClientId)" -and $ENV:AZSTORAGECLIENTID -ne "") { $AzStorageClientIdIsSet = $true } else { $AzStorageClientIdIsSet = $false }
+if ($ENV:AZSTORAGECLIENTSECRET -ne "`$(AzStorageClientSecret)" -and $ENV:AZSTORAGECLIENTSECRET -ne "") { $AzStorageClientSecretIsSet = $true } else { $AzStorageClientSecretIsSet = $false }
+
+if ($AzStorageTenantIdIsSet -and $AzStorageClientIdIsSet -and $AzStorageClientSecretIsSet) {
+    Write-Host "Set downloadFromPrivateAzureStorage = $true"
+    Write-Host "##vso[task.setvariable variable=downloadFromPrivateAzureStorage]$true"
+}


### PR DESCRIPTION
A small  update :) So that we can download License file, app dependencies and Certificate for signing from a private Azure Storage Container using Oauth2. This will only apply for URL's that contains blob.core.windows.net. What do you think? :)

New Library Variables

- AzStorageClientId
- AzStorageClientSecret
- AzStorageTenantId